### PR TITLE
fixed CAAnimationDelegate  warning

### DIFF
--- a/BFPaperButton/BFPaperButton-Info.plist
+++ b/BFPaperButton/BFPaperButton-Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>2</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>

--- a/Classes/BFPaperButton.h
+++ b/Classes/BFPaperButton.h
@@ -38,7 +38,7 @@ extern CGFloat const bfPaperButton_tapCircleDiameterFull;
 extern CGFloat const bfPaperButton_tapCircleDiameterDefault;
 
 IB_DESIGNABLE
-@interface BFPaperButton : UIButton <UIGestureRecognizerDelegate>
+@interface BFPaperButton : UIButton <UIGestureRecognizerDelegate, CAAnimationDelegate>
 
 /* Notes on RAISED vs FLAT and SMART COLOR vs NON SMART COLOR:
  *


### PR DESCRIPTION
This fix is necessary for Xcode 8.3 to fix CAAnimationDelegate warning