### PR TITLE
remove delegate for global animation

### DIFF
--- a/Classes/BFPaperButton.m
+++ b/Classes/BFPaperButton.m
@@ -282,8 +282,6 @@ CGFloat const bfPaperButton_tapCircleDiameterDefault = -2.f;
     UITapGestureRecognizer *tapGestureRecognizer = [[UITapGestureRecognizer alloc] initWithTarget:self action:nil];
     tapGestureRecognizer.delegate = self;
     [self addGestureRecognizer:tapGestureRecognizer];
-    
-    [UIView setAnimationDidStopSelector:@selector(animationDidStop:finished:)];
 }
 
 


### PR DESCRIPTION
In iOS 13 has an error. And these line doesn't need.